### PR TITLE
Added Success params/fields to template

### DIFF
--- a/templates/default.md
+++ b/templates/default.md
@@ -31,7 +31,7 @@
 | Name    | Type      | Description                          |
 |---------|-----------|--------------------------------------|
 <% data[group][sub][0].header.fields.Header.forEach(function (header) { -%>
-| <%- header.field %>			| <%- header.type %>			| <%- header.optional ? '**optional**' : '' %> <%- header.description %>							|
+| <%- header.field %> | <%- header.type %> | <%- header.optional ? '**optional**' : '' %><%- header.description %>|
 <% }); //forech parameter -%>
 <% } //if parameters -%>
 <% if (data[group][sub][0].parameter) { -%>
@@ -43,7 +43,7 @@
 | Name     | Type       | Description                           |
 |:---------|:-----------|:--------------------------------------|
 <% data[group][sub][0].parameter.fields[g].forEach(function (param) { -%>
-| <%- param.field %>                   | <%- param.type %>                     | <%- param.optional ? '**optional**' : '' %> <%- param.description -%>
+| <%- param.field %> | <%- param.type %> | <%- param.optional ? '**optional**' : '' %><%- param.description -%>
 <% if (param.defaultValue) { -%>
 _Default value: <%= param.defaultValue %>_<br><% } -%>
 <% if (param.size) { -%>
@@ -54,7 +54,6 @@ _Allowed values: <%- param.allowedValues %>_<% } %>|
 <% }); //forech param parameter -%>
 <% } //if parameters -%>
 <% if (data[group][sub][0].examples && data[group][sub][0].examples.length) { -%>
-
 ### Examples
 
 <% data[group][sub][0].examples.forEach(function (example) { -%>
@@ -85,7 +84,7 @@ _Allowed values: <%- param.allowedValues %>_<% } %>|
 | Name     | Type       | Description                           |
 |:---------|:-----------|:--------------------------------------|
 <% data[group][sub][0].success.fields[g].forEach(function (param) { -%>
-| <%- param.field %>			| <%- param.type %>			| <%- param.optional ? '**optional**' : '' %><%- param.description -%>
+| <%- param.field %> | <%- param.type %> | <%- param.optional ? '**optional**' : '' %><%- param.description -%>
 <% if (param.defaultValue) { -%>
 _Default value: <%- param.defaultValue %>_<br><% } -%>
 <% if (param.size) { -%>

--- a/templates/default.md
+++ b/templates/default.md
@@ -40,10 +40,16 @@
 
 ### <%= g %> Parameters
 
-| Name     | Type       | Description                           | Default    | Allowed   |
-|:---------|:-----------|:--------------------------------------|:-----------|:-----------|
+| Name     | Type       | Description                           |
+|:---------|:-----------|:--------------------------------------|
 <% data[group][sub][0].parameter.fields[g].forEach(function (param) { -%>
-| <%- param.field %>			| <%- param.type %>			| <%- param.optional ? '**optional**' : '' %> <%- param.description %>							| <%- param.defaultValue %>			| <%- param.allowedValues %>			|
+| <%- param.field %>                   | <%- param.type %>                     | <%- param.optional ? '**optional**' : '' %> <%- param.description -%>
+<% if (param.defaultValue) { -%>
+_Default value: <%= param.defaultValue %>_<br><% } -%>
+<% if (param.size) { -%>
+_Size range: <%- param.size %>_<br><% } -%>
+<% if (param.allowedValues) { -%>
+_Allowed values: <%- param.allowedValues %>_<% } %>|
 <% }); //forech (group) parameter -%>
 <% }); //forech param parameter -%>
 <% } //if parameters -%>
@@ -71,6 +77,25 @@
 ```
 <% }); //foreach success example -%>
 <% } //if examples -%>
+
+<% if (data[group][sub][0].success && data[group][sub][0].success.fields) { -%>
+<% Object.keys(data[group][sub][0].success.fields).forEach(function(g) { -%>
+### <%= g %>
+
+| Name     | Type       | Description                           |
+|:---------|:-----------|:--------------------------------------|
+<% data[group][sub][0].success.fields[g].forEach(function (param) { -%>
+| <%- param.field %>			| <%- param.type %>			| <%- param.optional ? '**optional**' : '' %><%- param.description -%>
+<% if (param.defaultValue) { -%>
+_Default value: <%- param.defaultValue %>_<br><% } -%>
+<% if (param.size) { -%>
+_Size range: <%- param.size -%>_<br><% } -%>
+<% if (param.allowedValues) { -%>
+_Allowed values: <%- param.allowedValues %>_<% } %>|
+<% }); //forech (group) parameter -%>
+<% }); //forech field -%>
+<% } //if success.fields -%>
+
 <% if (data[group][sub][0].error && data[group][sub][0].error.examples && data[group][sub][0].error.examples.length) { -%>
 ### Error Response
 


### PR DESCRIPTION
Several Template fixes:
- Added Success params/fields to the output
- Removed last two columns for request and success (more room for description)
- Moved Allowed, Default into Description block, with c/r and italics
- Added size range with same formatting
